### PR TITLE
Remove Airbnb Eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,13 +4,18 @@
     "sourceType": "module",
     "allowImportExportEverywhere": true
   },
-  "extends": ["airbnb", "prettier", "prettier/flowtype", "prettier/react"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "prettier",
+    "prettier/flowtype",
+    "prettier/react"
+  ],
   "env": {
     "browser": true,
     "node": true
   },
   "rules": {
-    "arrow-parens": ["off"],
     "compat/compat": "error",
     "consistent-return": "off",
     "comma-dangle": "off",
@@ -34,7 +39,6 @@
     "generator-star-spacing": "off",
     "import/no-unresolved": "error",
     "import/no-extraneous-dependencies": "off",
-    "jsx-a11y/anchor-is-valid": "off",
     "no-console": "off",
     "no-use-before-define": "off",
     "no-multi-assign": "off",
@@ -59,11 +63,16 @@
       "error",
       { "extensions": [".js", ".jsx"] }
     ],
-    "react/prefer-stateless-function": "off"
+    "react/prop-types": "off",
+    "react/prefer-stateless-function": "off",
+    "react/no-string-refs": "warn"
   },
   "plugins": ["flowtype", "import", "promise", "compat", "react"],
   "settings": {
     "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx"]
+      },
       "webpack": {
         "config": "webpack.config.eslint.js"
       }

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,8 @@
   ],
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
+    "es6": true
   },
   "rules": {
     "compat/compat": "error",
@@ -46,6 +47,7 @@
     "promise/always-return": "error",
     "promise/catch-or-return": "error",
     "promise/no-native": "off",
+    "react/display-name": "off",
     "react/sort-comp": [
       "error",
       {

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,5 @@
         "parser": "json"
       }
     }
-  ],
-  "singleQuote": true
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,6 @@
     "npm-debug.log.*": true,
     "test/**/__snapshots__": true,
     "yarn.lock": true
-  }
+  },
+  "editor.formatOnSave": true
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "browserslist": "electron 1.6",
   "lint-staged": {
     "*.(js|jsx)": [
-      "cross-env NODE_ENV=development eslint --cache --format=node_modules/eslint-formatter-pretty",
+      "cross-env NODE_ENV=development eslint --cache --format=node_modules/eslint-formatter-pretty --fix",
       "prettier --ignore-path .eslintignore --single-quote --write",
       "git add"
     ],
@@ -160,7 +160,6 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.4",
     "eslint": "^5.2.0",
-    "eslint-config-airbnb": "^17.0.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-formatter-pretty": "^1.3.0",
     "eslint-import-resolver-webpack": "^0.10.1",
@@ -168,7 +167,6 @@
     "eslint-plugin-flowtype": "^2.50.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-jest": "^21.18.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-react": "^7.10.0",
     "express": "^4.16.3",


### PR DESCRIPTION
This changes the default to what _should_ be a much more reasonable linter config.

This will also automatically fix what ESLint can fix automatically when you commit.

Let me know if something is bothering you too much and we can relax more things.

I've also added Format on save to the vscode settings, so prettier will run every time you save.