### PR TITLE
Git Reset Functionality

### DIFF
--- a/app/git-abs/git-abs.js
+++ b/app/git-abs/git-abs.js
@@ -178,7 +178,7 @@ class GitAbs {
    * @param {String} commitHash
    */
   reset = async (fileName, commitHash) =>
-    git.reset(this.repository, fileName, commitHash);
+    await git.reset(this.repository, fileName, commitHash);
 }
 
 /* eslint-enable */

--- a/app/git-abs/git-abs.js
+++ b/app/git-abs/git-abs.js
@@ -171,6 +171,14 @@ class GitAbs {
    * Returns list of files in the project
    */
   getFiles = () => this.metadata.getAllBranches();
+
+  /**
+   * Performs a hard reset on the given file to a previous commit
+   * @param {String} fileName
+   * @param {String} commitHash
+   */
+  reset = async (fileName, commitHash) =>
+    git.reset(this.repository, fileName, commitHash);
 }
 
 /* eslint-enable */

--- a/app/git-abs/git/reset.js
+++ b/app/git-abs/git/reset.js
@@ -6,7 +6,7 @@ import { Commit, Reset, Oid, CheckoutOptions } from "nodegit";
  * @param {String} branchName
  * @param {String} commitHash
  */
-const reset = repo => branchName => commitHash => {
+const reset = repo => branchName => commitHash =>
   Commit.lookup(repo, Oid.fromString(commitHash))
     .then(commit =>
       Reset.reset(
@@ -18,6 +18,5 @@ const reset = repo => branchName => commitHash => {
       )
     )
     .catch(err => console.error("Error in Commit.lookup: ", err));
-};
 
 export default reset;

--- a/app/git-abs/git/reset.js
+++ b/app/git-abs/git/reset.js
@@ -1,0 +1,23 @@
+import { Commit, Reset, Oid, CheckoutOptions } from "nodegit";
+
+/**
+ * Performs a hard reset on the branchName inside the repo to the commitHash
+ * @param {Repository (nodegit)} repo
+ * @param {String} branchName
+ * @param {String} commitHash
+ */
+const reset = repo => branchName => commitHash => {
+  Commit.lookup(repo, Oid.fromString(commitHash))
+    .then(commit =>
+      Reset.reset(
+        repo,
+        commit,
+        Reset.TYPE.HARD,
+        new CheckoutOptions(),
+        branchName
+      )
+    )
+    .catch(err => console.error("Error in Commit.lookup: ", err));
+};
+
+export default reset;

--- a/app/git-abs/git/reset.js
+++ b/app/git-abs/git/reset.js
@@ -17,6 +17,6 @@ const reset = repo => branchName => commitHash =>
         branchName
       )
     )
-    .catch(err => console.error("Error in Commit.lookup: ", err));
+    .catch(e => throw new Error(`Error in checkpoint reset ${e}`));
 
 export default reset;


### PR DESCRIPTION
After some tinkering around I figured out we can't actually use git's reverting functionality because reverting commits can lead to merge conflicts 👎 

So, instead we'll be providing a way to totally reset back to a checkpoint. This PR adds the nodegit functionality and GitAbs method to do just that! 