### PR TITLE
Fix Autosave 

### DIFF
--- a/app/components/AutoSave.js
+++ b/app/components/AutoSave.js
@@ -22,9 +22,7 @@ export class AutoSave extends React.Component {
     if (gitAbstractions && currentFile && editorState) {
       gitAbstractions
         .saveFile(currentFile, convertToRaw(editorState.getCurrentContent()))
-        .then(() => {
-          gitAbstractions.getLatestTime(currentFile);
-        })
+        .then(() => gitAbstractions.getLatestTime(currentFile))
         .then(time => dispatch({ type: UPDATE_LAST_SAVED, payload: time }))
         .catch(err => {
           console.error("Error autosaving", err);


### PR DESCRIPTION
Autosave functionality wasn't returning the time stamp from gitAbstractions to pass to action dispatch. So, autosaving wasn't updating the Last Save box.

Now it's fixed.