### PR TITLE
Viewing Checkpoint Autosave Fix 

### DIFF
--- a/app/components/History/CheckpointCard.js
+++ b/app/components/History/CheckpointCard.js
@@ -92,6 +92,9 @@ export class CheckpointCard extends React.Component {
                       })
                     )
                     .then(() =>
+                      gitAbstractions.switchToCurrentVersion(currentFile)
+                    )
+                    .then(() =>
                       dispatch({ type: SET_VIEW_STATE, payload: commit })
                     )
                     .catch(e => {


### PR DESCRIPTION
Fix: Switch back to current version before switching to markdown view avoiding Autosave's save() function from being invoked while in previous version.